### PR TITLE
Lift get_config_data from npg_notifications.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Added .github/dependabot.yml file to auto-update GitHub actions
 * Implemented the `create_token` action. Provided the caller has an admin token,
   this action generates and returns a new pipeline-specific token.
-* Brought some semi-standard Porch client config over from npg_notifications to
-  improve reusability
+* Used npg-python-lib to read Porch config
 
 ## [0.1.0] - 2024-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [0.2.0] - 2024-12-18
 
 ### Added
 
 * Added .github/dependabot.yml file to auto-update GitHub actions
 * Implemented the `create_token` action. Provided the caller has an admin token,
   this action generates and returns a new pipeline-specific token.
+* Brought some semi-standard Porch client config over from npg_notifications to
+  improve reusability
 
 ## [0.1.0] - 2024-07-23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ npg_porch_client = "npg_porch_cli.api_cli_user:run"
 [tool.poetry.dependencies]
 python = "^3.10"
 requests = "^2.31.0"
+npg-python-lib = { git="https://github.com/wtsi-npg/npg-python-lib", tag="0.3.4"}
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "npg_porch_cli"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "Marina Gourtovaia",
     "Kieron Taylor",
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "GPL-3.0-or-later"
 
 [tool.poetry.scripts]
-npg_porch_client = "npg_porch_cli.api_cli_user:run" 
+npg_porch_client = "npg_porch_cli.api_cli_user:run"
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/src/npg_porch_cli/config.py
+++ b/src/npg_porch_cli/config.py
@@ -1,0 +1,98 @@
+import configparser
+import json
+import pathlib
+from dataclasses import dataclass
+
+"""Common utility functions for the package."""
+
+DEFAULT_CONF_FILE_TYPE = "ini"
+
+
+def get_config_data(conf_file_path: str, conf_file_section: str = None):
+    """
+    Parses a configuration file and returns its content.
+
+    Allows for two types of configuration files, 'ini' and 'json'. The type of
+    the file is determined from the extension of the file name. In case of no
+    extension an 'ini' type is assumed.
+
+    The content of the file is not cached, so subsequent calls to get data from
+    the same configuration file result in re-reading and re-parsing of the file.
+
+    Args:
+
+      conf_file_path:
+        A configuration file with database connection details.
+      conf_file_section:
+        The section of the configuration file. Optional. Should be defined
+        for 'ini' files.
+
+    Returns:
+      For an 'ini' file returns the content of the given section of the file as
+      a dictionary.
+      For a 'json' file, if the conf_file_section argument is not defined, the
+      content of a file as a Python object is returned. If the conf_file_section
+      argument is defined, the object returned by the parser is assumed to be
+      a dictionary that has the value of the 'conf_file_section' argument as a key.
+      The value corresponding to this key is returned.
+    """
+
+    path = pathlib.Path(conf_file_path)
+
+    conf_file_extension = path.suffix
+    if conf_file_extension:
+        conf_file_extension = conf_file_extension[1:]
+    else:
+        conf_file_extension = DEFAULT_CONF_FILE_TYPE
+
+    if conf_file_extension == DEFAULT_CONF_FILE_TYPE:
+        if not conf_file_section:
+            raise Exception(
+                "'conf_file_section' argument is not given, "
+                "it should be defined for '{DEFAULT_CONF_FILE_TYPE}' "
+                "configuration file."
+            )
+
+        config = configparser.ConfigParser()
+        with open(conf_file_path) as cf:
+            if not cf.readable():
+                raise Exception(f"{path} has a permissions issue")
+
+            config.read_file(cf)
+
+        return {i[0]: i[1] for i in config[conf_file_section].items()}
+
+    elif conf_file_extension == "json":
+        conf: dict = json.load(conf_file_path)
+        if conf_file_section:
+            if isinstance(conf, dict) is False:
+                raise Exception(f"{conf_file_path} does not have sections.")
+            if conf_file_section in conf.keys:
+                conf = conf[conf_file_section]
+            else:
+                raise Exception(
+                    f"{conf_file_path} does not contain {conf_file_section} key"
+                )
+
+        return conf
+
+    else:
+        raise Exception(f"Parsing for '{conf_file_extension}' files is not implemented")
+
+
+@dataclass(frozen=True, kw_only=True)
+class PorchClientConfig:
+    """
+    Suggested config file content for interacting with a Porch server instance
+    """
+
+    api_url: str
+    pipeline_name: str
+    pipeline_uri: str
+    pipeline_version: str
+    npg_porch_token: str
+
+    @classmethod
+    def from_config_file(cls, conf_file_path: str, conf_file_section: str = "PORCH"):
+        conf = get_config_data(conf_file_path, conf_file_section=conf_file_section)
+        return cls(**conf)

--- a/src/npg_porch_cli/config.py
+++ b/src/npg_porch_cli/config.py
@@ -1,23 +1,28 @@
-import configparser
-import json
-import pathlib
 from dataclasses import dataclass
+from os import R_OK, access
+from os.path import isfile
 
-"""Common utility functions for the package."""
-
-DEFAULT_CONF_FILE_TYPE = "ini"
+from npg.conf import IniData
 
 
-def get_config_data(conf_file_path: str, conf_file_section: str = None):
+@dataclass(frozen=True, kw_only=True)
+class PorchClientConfig:
+    """
+    Suggested config file content for interacting with a Porch server instance
+    """
+
+    api_url: str
+    pipeline_name: str
+    pipeline_uri: str
+    pipeline_version: str
+    npg_porch_token: str
+
+
+def get_config_data(
+    conf_file_path: str, conf_file_section: str = "PORCH"
+) -> PorchClientConfig:
     """
     Parses a configuration file and returns its content.
-
-    Allows for two types of configuration files, 'ini' and 'json'. The type of
-    the file is determined from the extension of the file name. In case of no
-    extension an 'ini' type is assumed.
-
-    The content of the file is not cached, so subsequent calls to get data from
-    the same configuration file result in re-reading and re-parsing of the file.
 
     Args:
 
@@ -37,62 +42,11 @@ def get_config_data(conf_file_path: str, conf_file_section: str = None):
       The value corresponding to this key is returned.
     """
 
-    path = pathlib.Path(conf_file_path)
-
-    conf_file_extension = path.suffix
-    if conf_file_extension:
-        conf_file_extension = conf_file_extension[1:]
+    if isfile(conf_file_path) and access(conf_file_path, R_OK):
+        porch_conf = IniData(PorchClientConfig).from_file(
+            conf_file_path, conf_file_section
+        )
     else:
-        conf_file_extension = DEFAULT_CONF_FILE_TYPE
+        raise FileNotFoundError(f"{conf_file_path} is not present or cannot be read")
 
-    if conf_file_extension == DEFAULT_CONF_FILE_TYPE:
-        if not conf_file_section:
-            raise Exception(
-                "'conf_file_section' argument is not given, "
-                "it should be defined for '{DEFAULT_CONF_FILE_TYPE}' "
-                "configuration file."
-            )
-
-        config = configparser.ConfigParser()
-        with open(conf_file_path) as cf:
-            if not cf.readable():
-                raise Exception(f"{path} has a permissions issue")
-
-            config.read_file(cf)
-
-        return {i[0]: i[1] for i in config[conf_file_section].items()}
-
-    elif conf_file_extension == "json":
-        conf: dict = json.load(conf_file_path)
-        if conf_file_section:
-            if isinstance(conf, dict) is False:
-                raise Exception(f"{conf_file_path} does not have sections.")
-            if conf_file_section in conf.keys:
-                conf = conf[conf_file_section]
-            else:
-                raise Exception(
-                    f"{conf_file_path} does not contain {conf_file_section} key"
-                )
-
-        return conf
-
-    else:
-        raise Exception(f"Parsing for '{conf_file_extension}' files is not implemented")
-
-
-@dataclass(frozen=True, kw_only=True)
-class PorchClientConfig:
-    """
-    Suggested config file content for interacting with a Porch server instance
-    """
-
-    api_url: str
-    pipeline_name: str
-    pipeline_uri: str
-    pipeline_version: str
-    npg_porch_token: str
-
-    @classmethod
-    def from_config_file(cls, conf_file_path: str, conf_file_section: str = "PORCH"):
-        conf = get_config_data(conf_file_path, conf_file_section=conf_file_section)
-        return cls(**conf)
+    return porch_conf

--- a/tests/data/conf.ini
+++ b/tests/data/conf.ini
@@ -1,0 +1,17 @@
+[STUFF]
+
+logging = INFO
+
+[PORCH]
+
+api_url = https://porch.dnapipelines.sanger.ac.uk
+pipeline_name = test_pipeline
+pipeline_uri = https://test.pipeline.com
+pipeline_version = 9.9.9
+npg_porch_token = 0123456789abcdef0123456789abcdef
+
+[PARTIALPORCH]
+
+api_url = https://porch.dnapipelines.sanger.ac.uk
+pipeline_name = test_pipeline
+pipeline_uri = https://test.pipeline.com

--- a/tests/test_porch_client_config.py
+++ b/tests/test_porch_client_config.py
@@ -3,33 +3,15 @@ from pytest import raises
 from npg_porch_cli.config import PorchClientConfig, get_config_data
 
 
-def test_config_file_reading():
-    conf = get_config_data(
-        conf_file_path="tests/data/conf.ini", conf_file_section="STUFF"
-    )
-
-    assert conf == {"logging": "INFO"}
-
-
 def test_conf_obj():
-    config_obj = PorchClientConfig.from_config_file("tests/data/conf.ini")
+    config_obj = get_config_data("tests/data/conf.ini")
     assert config_obj.pipeline_name == "test_pipeline"
     assert config_obj.pipeline_version == "9.9.9"
 
-    with raises(KeyError, match="ABSENT"):
-        PorchClientConfig.from_config_file(
-            "tests/data/conf.ini", conf_file_section="ABSENT"
-        )
+    assert type(config_obj) is PorchClientConfig
 
-    with raises(FileNotFoundError, match="No such file or directory: 'notafile'"):
-        PorchClientConfig.from_config_file("notafile", conf_file_section="ABSENT")
-
-    with raises(TypeError, match="unexpected keyword argument 'logging'"):
-        PorchClientConfig.from_config_file(
-            "tests/data/conf.ini", conf_file_section="STUFF"
-        )
+    with raises(FileNotFoundError, match="notafile is not present or cannot be read"):
+        get_config_data("notafile", conf_file_section="ABSENT")
 
     with raises(TypeError, match="missing 2 required keyword-only arguments"):
-        PorchClientConfig.from_config_file(
-            "tests/data/conf.ini", conf_file_section="PARTIALPORCH"
-        )
+        get_config_data("tests/data/conf.ini", conf_file_section="PARTIALPORCH")

--- a/tests/test_porch_client_config.py
+++ b/tests/test_porch_client_config.py
@@ -16,22 +16,20 @@ def test_conf_obj():
     assert config_obj.pipeline_name == "test_pipeline"
     assert config_obj.pipeline_version == "9.9.9"
 
-    with raises(Exception):
+    with raises(KeyError, match="ABSENT"):
         PorchClientConfig.from_config_file(
             "tests/data/conf.ini", conf_file_section="ABSENT"
         )
 
-    with raises(Exception):
+    with raises(FileNotFoundError, match="No such file or directory: 'notafile'"):
         PorchClientConfig.from_config_file("notafile", conf_file_section="ABSENT")
 
-    with raises(TypeError) as e:
+    with raises(TypeError, match="unexpected keyword argument 'logging'"):
         PorchClientConfig.from_config_file(
             "tests/data/conf.ini", conf_file_section="STUFF"
         )
-    assert e.match("unexpected keyword argument 'logging'")
 
-    with raises(Exception) as e:
+    with raises(TypeError, match="missing 2 required keyword-only arguments"):
         PorchClientConfig.from_config_file(
             "tests/data/conf.ini", conf_file_section="PARTIALPORCH"
         )
-    assert e.match("missing 2 required keyword-only arguments")

--- a/tests/test_porch_client_config.py
+++ b/tests/test_porch_client_config.py
@@ -1,0 +1,37 @@
+from pytest import raises
+
+from npg_porch_cli.config import PorchClientConfig, get_config_data
+
+
+def test_config_file_reading():
+    conf = get_config_data(
+        conf_file_path="tests/data/conf.ini", conf_file_section="STUFF"
+    )
+
+    assert conf == {"logging": "INFO"}
+
+
+def test_conf_obj():
+    config_obj = PorchClientConfig.from_config_file("tests/data/conf.ini")
+    assert config_obj.pipeline_name == "test_pipeline"
+    assert config_obj.pipeline_version == "9.9.9"
+
+    with raises(Exception):
+        PorchClientConfig.from_config_file(
+            "tests/data/conf.ini", conf_file_section="ABSENT"
+        )
+
+    with raises(Exception):
+        PorchClientConfig.from_config_file("notafile", conf_file_section="ABSENT")
+
+    with raises(TypeError) as e:
+        PorchClientConfig.from_config_file(
+            "tests/data/conf.ini", conf_file_section="STUFF"
+        )
+    assert e.match("unexpected keyword argument 'logging'")
+
+    with raises(Exception) as e:
+        PorchClientConfig.from_config_file(
+            "tests/data/conf.ini", conf_file_section="PARTIALPORCH"
+        )
+    assert e.match("missing 2 required keyword-only arguments")


### PR DESCRIPTION
Improve error handling by checking for a necessary config file because configparser tolerates invalid inputs. Use a dataclass to validate all properties are set in conf.

Related PR on npg_notifications needed